### PR TITLE
Chopper util chops too many leaves

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@ mod_name=Deforestry
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=All Rights Reserved
 # The mod version. See https://semver.org/
-mod_version=0.5.1
+mod_version=0.5.2
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/org/erg/deforestry/common/entity/BoomerangChopperEntity.java
+++ b/src/main/java/org/erg/deforestry/common/entity/BoomerangChopperEntity.java
@@ -58,7 +58,7 @@ public class BoomerangChopperEntity extends BoomerangEntity {
 
                     for (int i = 0; i < logsToChop; i++) {
                         level.destroyBlock(logs.get(i), true, player);
-                        for (BlockPos leaf : DeforestryUtil.getConnectedLeavesAroundLog(logs.get(i), level)) {
+                        for (BlockPos leaf : DeforestryUtil.getConnectedLeavesAroundLog(logs.get(i), level, logs)) {
                             level.destroyBlock(leaf, true, player);
                         }
                     }

--- a/src/main/java/org/erg/deforestry/common/item/ChainsawItem.java
+++ b/src/main/java/org/erg/deforestry/common/item/ChainsawItem.java
@@ -173,7 +173,7 @@ public class ChainsawItem extends Item {
                         level.addFreshEntity(new ItemEntity(level, player.getX(), player.getY(), player.getZ(), choppedLog));
                     }
 
-                    for(BlockPos leaf: DeforestryUtil.getConnectedLeavesAroundLog(logs.get(i), level)) {
+                    for(BlockPos leaf: DeforestryUtil.getConnectedLeavesAroundLog(logs.get(i), level, logs)) {
                         BlockState blockState = level.getBlockState(leaf);
                         for(ItemStack item: blockState.getDrops(lootBuilder)) {
                             if(!player.addItem(item)) {

--- a/src/main/java/org/erg/deforestry/common/item/FellingAxeItem.java
+++ b/src/main/java/org/erg/deforestry/common/item/FellingAxeItem.java
@@ -37,7 +37,7 @@ public class FellingAxeItem extends AxeItem {
 
                 for(int i = 0; i < logsToChop; i++) {
                     level.destroyBlock(logs.get(i), true, breaker);
-                    for(BlockPos leaf: DeforestryUtil.getConnectedLeavesAroundLog(logs.get(i), level)) {
+                    for(BlockPos leaf: DeforestryUtil.getConnectedLeavesAroundLog(logs.get(i), level, logs)) {
                         level.destroyBlock(leaf, true, breaker);
                     }
                     heldItem.hurtAndBreak(1, breaker, (e) -> e.broadcastBreakEvent(EquipmentSlot.MAINHAND));

--- a/src/main/java/org/erg/deforestry/common/item/RemoteChopperItem.java
+++ b/src/main/java/org/erg/deforestry/common/item/RemoteChopperItem.java
@@ -51,7 +51,7 @@ public class RemoteChopperItem extends Item {
                     int logsToChop = Math.min(Math.min(stack.getMaxDamage() - stack.getDamageValue(), numLogs), Config.maxRemoteChop);
                     for (int i = 0; i < logsToChop; i++) {
                         level.destroyBlock(logs.get(i), true, player);
-                        for(BlockPos leaf: DeforestryUtil.getConnectedLeavesAroundLog(logs.get(i), level)) {
+                        for(BlockPos leaf: DeforestryUtil.getConnectedLeavesAroundLog(logs.get(i), level, logs)) {
                             level.destroyBlock(leaf, true, player);
                         }
                     }

--- a/src/main/java/org/erg/deforestry/common/util/DeforestryUtil.java
+++ b/src/main/java/org/erg/deforestry/common/util/DeforestryUtil.java
@@ -84,9 +84,10 @@ public class DeforestryUtil {
     }
 
     @NotNull
-    public static List<BlockPos> getConnectedLeavesAroundLog(BlockPos log, Level level) {
+    public static List<BlockPos> getConnectedLeavesAroundLog(BlockPos log, Level level, final List<BlockPos> originTree) {
         Set<BlockPos> leaves = new HashSet<>();
         Stack<BlockPos> toSearch = new Stack<>();
+        List<List<BlockPos>> surroundingTrees = new ArrayList<>();
         toSearch.add(log);
 
         AABB range = AABB.encapsulatingFullBlocks(log.below(4).west(4).south(4), log.above(4).east(4).north(4));
@@ -102,14 +103,72 @@ public class DeforestryUtil {
                             range.contains(pos.getX(), pos.getY(), pos.getZ())) {
                         toSearch.add(pos);
                     }
+                } else if(level.getBlockState(pos).is(BlockTags.LOGS) && !originTree.contains(pos) && !logInTrees(pos, surroundingTrees)) {
+                    surroundingTrees.add(getLogsInTree(level.getBlockState(pos).getBlock(), pos, level));
                 }
             }
 
             if(level.getBlockState(center).is(BlockTags.LEAVES))
                 leaves.add(center);
         }
-        return new ArrayList<>(leaves);
 
+        List<BlockPos> boundingAxes = new ArrayList<>();
+        for(List<BlockPos> tree: surroundingTrees) {
+            int highX = Integer.MIN_VALUE, highZ = Integer.MIN_VALUE, lowX = Integer.MAX_VALUE, lowZ = Integer.MAX_VALUE;
+            for(BlockPos pos: tree) {
+                if(pos.getX() > highX)
+                    highX = pos.getX();
+                if(pos.getX() < lowX)
+                    lowX = pos.getX();
+                if(pos.getZ() > highZ)
+                    highZ = pos.getZ();
+                if(pos.getZ() < lowZ)
+                    lowZ = pos.getZ();
+            }
+
+            int midX = lowX + ((highX - lowX) / 2);
+            int midZ = lowZ + ((highZ - lowZ) / 2);
+
+            boundingAxes.add(new BlockPos(midX, log.getY(), midZ));
+        }
+
+        AABB validLeaves = new AABB(log).inflate(4.0d);
+
+        for(BlockPos axis: boundingAxes) {
+            BlockPos diff = axis.subtract(log);
+            BlockPos midpoint = log.offset(diff.getX() / 2, diff.getY() / 2, diff.getZ() / 2);
+            BlockPos midpointDiff = midpoint.subtract(log);
+
+            int xSigned = midpointDiff.getX() < 0 ? -1 : 1;
+            int zSigned = midpointDiff.getZ() < 0 ? -1 : 1;
+
+            int contractAmountX = Math.abs(midpointDiff.getX()) < 4 && Math.abs(midpointDiff.getX()) > 0 ? (4 * xSigned) - midpointDiff.getX() : 0;
+            int contractAmountZ = Math.abs(midpointDiff.getZ()) < 4 && Math.abs(midpointDiff.getZ()) > 0 ? (4 * zSigned) - midpointDiff.getZ() : 0;
+
+            validLeaves = validLeaves.contract(contractAmountX, 0, contractAmountZ);
+
+            Deforestry.LOGGER.debug("bounding midpoint: " + midpoint.getX() + " " + midpoint.getZ());
+            Deforestry.LOGGER.debug("bounding midpoint delta: " + midpointDiff.getX() + " " + midpointDiff.getZ());
+            Deforestry.LOGGER.debug("Contract Amounts: " + contractAmountX + " " + contractAmountZ);
+        }
+
+        AABB finalValidLeaves = validLeaves;
+        leaves.removeIf(e -> !finalValidLeaves.contains(e.getX(), e.getY(), e.getZ()));
+
+        for(BlockPos axis: boundingAxes) {
+            Deforestry.LOGGER.debug("Bounding Axis: " + axis.getX() + " " + axis.getZ());
+        }
+
+        return new ArrayList<>(leaves);
+    }
+
+    @NotNull
+    public static boolean logInTrees(BlockPos pos, List<List<BlockPos>> trees) {
+        boolean found = false;
+        for(List<BlockPos> tree: trees) {
+            found = tree.stream().anyMatch(e -> e.equals(pos));
+        }
+        return found;
     }
 
 }


### PR DESCRIPTION
The improvement on this would be to contract a new bounding box for every tree rather than the same bounding box every time, and then take the intersection of those aabbs.
The next improvement on this would be to do that for every nearby log block instead of using collective trees.
Updated version to 0.5.2